### PR TITLE
Fix memo TextInput losing its value when quick mode is toggled

### DIFF
--- a/src/Screens/AmountsScreen/AmountView.tsx
+++ b/src/Screens/AmountsScreen/AmountView.tsx
@@ -140,6 +140,7 @@ export const AmountView = <T extends keyof StackParameterList>({
                             label='Memo'
                             placeholder='Enter memo'
                             mode='outlined'
+                            value={amountEntry.memo}
                             onChangeText={(text) => updateAmountEntry({ memo: text })}
                         />
                         <SplitPercentInput


### PR DESCRIPTION
Without a value prop the input was uncontrolled, so remounting it (on quick mode toggle) would reset the displayed text even though the stored memo was still in state.