### PR TITLE
Add error handling during fetching and saving

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -35,6 +35,10 @@ const ReduxProvidedApp = () => {
         return null;
     }
 
+    if (initialFetchStatus === InitialFetchStatus.ERROR) {
+        throw new Error('Failed to load app data');
+    }
+
     return (
         <View
             style={[styles.rootView, { backgroundColor: theme.colors.background }]}

--- a/src/Hooks/useEditableBudgetsInProfiles.ts
+++ b/src/Hooks/useEditableBudgetsInProfiles.ts
@@ -63,7 +63,7 @@ export const useEditableBudgetsInProfiles = (): Returning => {
                 finalizeEditableBudgetInProfile(budgetInProfile2),
             ],
         };
-        dispatch(saveProfile(profile));
+        await dispatch(saveProfile(profile));
     }, [finalizeEditableBudgetInProfile, budgetInProfile1, budgetInProfile2, dispatch]);
 
     return [

--- a/src/Hooks/useEditableBudgetsInProfiles.ts
+++ b/src/Hooks/useEditableBudgetsInProfiles.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { Updater, useImmer } from 'use-immer';
 import { BudgetInProfile, Profile, saveProfile, selectProfile } from '../redux/features/profile/profileSlice';
-import { useAppDispatch } from './useAppDispatch';
+import { useThrowingDispatch } from './useThrowingDispatch';
 import { useAppSelector } from './useAppSelector';
 
 export type EditableBudgetInProfile = {
@@ -28,7 +28,7 @@ export const useEditableBudgetsInProfiles = (): Returning => {
     const [budgetInProfile1, setBudgetInProfile1] = useImmer<EditableBudgetInProfile>(savedProfile ? savedProfile.budgets[0] : emptyBudgetInProfile);
     const [budgetInProfile2, setBudgetInProfile2] = useImmer<EditableBudgetInProfile>(savedProfile ? savedProfile.budgets[1] : emptyBudgetInProfile);
 
-    const dispatch = useAppDispatch();
+    const throwingDispatch = useThrowingDispatch();
 
     const isBudgetInProfileValid = useCallback((budgetInProfile: EditableBudgetInProfile): boolean => {
         return [
@@ -63,8 +63,8 @@ export const useEditableBudgetsInProfiles = (): Returning => {
                 finalizeEditableBudgetInProfile(budgetInProfile2),
             ],
         };
-        await dispatch(saveProfile(profile));
-    }, [finalizeEditableBudgetInProfile, budgetInProfile1, budgetInProfile2, dispatch]);
+        await throwingDispatch(saveProfile(profile));
+    }, [finalizeEditableBudgetInProfile, budgetInProfile1, budgetInProfile2, throwingDispatch]);
 
     return [
         budgetInProfile1,

--- a/src/Hooks/useInitialFetchStatus.ts
+++ b/src/Hooks/useInitialFetchStatus.ts
@@ -13,6 +13,7 @@ export enum InitialFetchStatus {
     UNKNOWN,
     READY,
     SETUP_REQUIRED,
+    ERROR,
 }
 
 export const useInitialFetchStatus = (): [InitialFetchStatus] => {
@@ -67,27 +68,37 @@ export const useInitialFetchStatus = (): [InitialFetchStatus] => {
         }
     }, [categoryCombosFetchStatus, dispatch]);
 
-    const localLoaded = useMemo(
+    const localStatus = useMemo(
         () => {
-            return accessTokenFetchStatus.status === LoadingStatus.SUCCESSFUL
-                && displaySettingsFetchStatus.status === LoadingStatus.SUCCESSFUL
-                && profileFetchStatus.status === LoadingStatus.SUCCESSFUL
-                && categoryCombosFetchStatus.status === LoadingStatus.SUCCESSFUL;
+            const statuses = [accessTokenFetchStatus, displaySettingsFetchStatus, profileFetchStatus, categoryCombosFetchStatus];
+            if (statuses.some((s) => s.status === LoadingStatus.ERROR)) {
+                return LoadingStatus.ERROR;
+            }
+            if (statuses.every((s) => s.status === LoadingStatus.SUCCESSFUL)) {
+                return LoadingStatus.SUCCESSFUL;
+            }
+            return LoadingStatus.LOADING;
         },
-        [accessTokenFetchStatus, categoryCombosFetchStatus, displaySettingsFetchStatus, profileFetchStatus],
+        [accessTokenFetchStatus, displaySettingsFetchStatus, profileFetchStatus, categoryCombosFetchStatus],
     );
 
     const initialFetchStatus = useMemo(
         () => {
-            if (localLoaded && (connectionStatus.status === LoadingStatus.ERROR || profile === null)) {
-                return InitialFetchStatus.SETUP_REQUIRED;
-            } else if (localLoaded && budgetsFetchStatus.status === LoadingStatus.SUCCESSFUL) {
-                return InitialFetchStatus.READY;
-            } else {
-                return InitialFetchStatus.UNKNOWN;
+            if (localStatus === LoadingStatus.ERROR) {
+                return InitialFetchStatus.ERROR;
             }
+            if (localStatus === LoadingStatus.SUCCESSFUL && (connectionStatus.status === LoadingStatus.ERROR || profile === null)) {
+                return InitialFetchStatus.SETUP_REQUIRED;
+            }
+            if (localStatus === LoadingStatus.SUCCESSFUL && budgetsFetchStatus.status === LoadingStatus.SUCCESSFUL) {
+                return InitialFetchStatus.READY;
+            }
+            if (localStatus === LoadingStatus.SUCCESSFUL && budgetsFetchStatus.status === LoadingStatus.ERROR) {
+                return InitialFetchStatus.SETUP_REQUIRED;
+            }
+            return InitialFetchStatus.UNKNOWN;
         },
-        [localLoaded, connectionStatus, profile, budgetsFetchStatus],
+        [localStatus, connectionStatus, profile, budgetsFetchStatus],
     );
 
     return [

--- a/src/Hooks/useThrowingDispatch.ts
+++ b/src/Hooks/useThrowingDispatch.ts
@@ -12,7 +12,7 @@ export const useThrowingDispatch = () => {
     const dispatch = useAppDispatch();
     return useCallback(
         async (action: Dispatchable) => {
-            const result = await dispatch(action as UnknownAction);
+            const result = await Promise.resolve(dispatch(action as UnknownAction));
             if (isRejected(result)) {
                 throw new Error(result.error.message ?? 'Unexpected error');
             }

--- a/src/Hooks/useThrowingDispatch.ts
+++ b/src/Hooks/useThrowingDispatch.ts
@@ -1,0 +1,23 @@
+import { useCallback } from 'react';
+import { isRejected, ThunkAction, UnknownAction } from '@reduxjs/toolkit';
+import { useAppDispatch } from './useAppDispatch';
+
+// createAsyncThunk dispatches never throw — they always resolve to either a
+// fulfilled or rejected action. This wrapper converts a rejection into a
+// thrown Error so call sites can use normal try/catch instead of inspecting
+// the action result manually.
+type Dispatchable = UnknownAction | ThunkAction<any, any, any, any>;
+
+export const useThrowingDispatch = () => {
+    const dispatch = useAppDispatch();
+    return useCallback(
+        async (action: Dispatchable) => {
+            const result = await dispatch(action as UnknownAction);
+            if (isRejected(result)) {
+                throw new Error(result.error.message ?? 'Unexpected error');
+            }
+            return result;
+        },
+        [dispatch],
+    );
+};

--- a/src/Screens/AmountsScreen/AmountsScreen.tsx
+++ b/src/Screens/AmountsScreen/AmountsScreen.tsx
@@ -194,6 +194,10 @@ export const AmountsScreen = ({ navigation, route }: MyStackScreenProps<ScreenNa
 
     const addingDisabled = remainingAmount === 0;
 
+    if (payerCategoriesFetchStatus === LoadingStatus.ERROR || debtorCategoriesFetchStatus === LoadingStatus.ERROR) {
+        throw new Error('Failed to load categories');
+    }
+
     const categoriesAreLoaded
         = payerCategoriesFetchStatus === LoadingStatus.SUCCESSFUL
         && debtorCategoriesFetchStatus === LoadingStatus.SUCCESSFUL;

--- a/src/Screens/Settings/AccessTokenScreen/AccessTokenScreen.tsx
+++ b/src/Screens/Settings/AccessTokenScreen/AccessTokenScreen.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { View } from 'react-native';
+import { Alert, View } from 'react-native';
 import { Appbar, Button } from 'react-native-paper';
 import { MyStackScreenProps } from '../../../Navigation/ScreenParameters';
 import { saveAccessToken, selectAccessToken } from '../../../redux/features/accessToken/accessTokenSlice';
@@ -8,7 +8,7 @@ import { LoadingStatus } from '../../../Helper/LoadingStatus';
 import { AccessTokenInput } from './AccessTokenInput';
 import { useNavigateBack } from '../../../Hooks/useNavigateBack';
 import { useConnectionTest } from '../../../Hooks/useConnectionTest';
-import { useAppDispatch } from '../../../Hooks/useAppDispatch';
+import { useThrowingDispatch } from '../../../Hooks/useThrowingDispatch';
 import { useNavigationSettings } from '../../../Hooks/useNavigationSettings';
 import { useTheme } from '../../../Hooks/useTheme';
 
@@ -21,7 +21,7 @@ const ICON_CONNECTION_SUCCESS = 'check';
 const ICON_CONNECTION_ERROR = 'alert-circle';
 
 export const AccessTokenScreen = ({ navigation }: MyStackScreenProps<ScreenName>) => {
-    const dispatch = useAppDispatch();
+    const throwingDispatch = useThrowingDispatch();
     const accessToken = useAppSelector(selectAccessToken);
     const [enteredToken, setEnteredToken] = useState<string>(accessToken);
     const [connectionStatus, testConnection] = useConnectionTest();
@@ -34,12 +34,16 @@ export const AccessTokenScreen = ({ navigation }: MyStackScreenProps<ScreenName>
                 icon={ICON_SAVE}
                 iconColor={theme.colors.onPrimary}
                 onPress={async () => {
-                    await dispatch(saveAccessToken(enteredToken));
-                    navigateBack();
+                    try {
+                        await throwingDispatch(saveAccessToken(enteredToken));
+                        navigateBack();
+                    } catch {
+                        Alert.alert('Error', 'Could not save. Please try again.');
+                    }
                 }}
             />
         ),
-        [dispatch, enteredToken, navigateBack, theme],
+        [throwingDispatch, enteredToken, navigateBack, theme],
     );
 
     useNavigationSettings({

--- a/src/Screens/Settings/AccessTokenScreen/AccessTokenScreen.tsx
+++ b/src/Screens/Settings/AccessTokenScreen/AccessTokenScreen.tsx
@@ -33,8 +33,8 @@ export const AccessTokenScreen = ({ navigation }: MyStackScreenProps<ScreenName>
             <Appbar.Action
                 icon={ICON_SAVE}
                 iconColor={theme.colors.onPrimary}
-                onPress={() => {
-                    dispatch(saveAccessToken(enteredToken));
+                onPress={async () => {
+                    await dispatch(saveAccessToken(enteredToken));
                     navigateBack();
                 }}
             />

--- a/src/Screens/Settings/CategoryCombos/CategoryComboSettingsScreen/CategoryComboSettingsScreen.tsx
+++ b/src/Screens/Settings/CategoryCombos/CategoryComboSettingsScreen/CategoryComboSettingsScreen.tsx
@@ -50,6 +50,10 @@ export const CategoryComboSettingsScreen = ({ navigation }: MyStackScreenProps<S
         }
     }, [dispatch, budgets, categoriesSecondProfileFetchStatus, accessToken]);
 
+    if (categoriesFirstProfileFetchStatus === LoadingStatus.ERROR || categoriesSecondProfileFetchStatus === LoadingStatus.ERROR) {
+        throw new Error('Failed to load categories');
+    }
+
     const everythingLoaded
         = categoriesFirstProfileFetchStatus === LoadingStatus.SUCCESSFUL
         && categoriesSecondProfileFetchStatus === LoadingStatus.SUCCESSFUL;

--- a/src/Screens/Settings/CategoryCombos/CreateCategoryComboScreen/CreateCategoryComboScreen.tsx
+++ b/src/Screens/Settings/CategoryCombos/CreateCategoryComboScreen/CreateCategoryComboScreen.tsx
@@ -29,12 +29,12 @@ export const CreateCategoryComboScreen = ({ navigation }: MyStackScreenProps<Scr
     const readyToSave = name.length > 0 && categoryIdFirstProfile;
 
     const saveAndNavigate = useCallback(
-        () => {
+        async () => {
             if (!categoryIdFirstProfile || !categoryIdSecondProfile) {
                 throw new Error('Not ready to save yet');
             }
 
-            dispatch(addCategoryCombo({
+            await dispatch(addCategoryCombo({
                 name: name,
                 categories: [
                     {

--- a/src/Screens/Settings/CategoryCombos/CreateCategoryComboScreen/CreateCategoryComboScreen.tsx
+++ b/src/Screens/Settings/CategoryCombos/CreateCategoryComboScreen/CreateCategoryComboScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
+import { Alert } from 'react-native';
 import { Appbar } from 'react-native-paper';
 import { CategoryComboInputView } from '../CategoryComboInputView';
 import { MyStackScreenProps } from '../../../../Navigation/ScreenParameters';
@@ -6,7 +7,7 @@ import { useNavigateBack } from '../../../../Hooks/useNavigateBack';
 import { addCategoryCombo } from '../../../../redux/features/categoryCombos/categoryCombosSlice';
 import { selectProfile } from '../../../../redux/features/profile/profileSlice';
 import { useAppSelector } from '../../../../Hooks/useAppSelector';
-import { useAppDispatch } from '../../../../Hooks/useAppDispatch';
+import { useThrowingDispatch } from '../../../../Hooks/useThrowingDispatch';
 import { useNavigationSettings } from '../../../../Hooks/useNavigationSettings';
 import { useTheme } from '../../../../Hooks/useTheme';
 
@@ -17,7 +18,7 @@ const ICON_SAVE = 'check';
 const SCREEN_TITLE = 'Create Category Combo';
 
 export const CreateCategoryComboScreen = ({ navigation }: MyStackScreenProps<ScreenName>) => {
-    const dispatch = useAppDispatch();
+    const throwingDispatch = useThrowingDispatch();
     const [navigateBack] = useNavigateBack(navigation);
     const [theme] = useTheme();
     const profile = useAppSelector(selectProfile);
@@ -34,21 +35,25 @@ export const CreateCategoryComboScreen = ({ navigation }: MyStackScreenProps<Scr
                 throw new Error('Not ready to save yet');
             }
 
-            await dispatch(addCategoryCombo({
-                name: name,
-                categories: [
-                    {
-                        budgetId: budgets[0].budgetId,
-                        id: categoryIdFirstProfile,
-                    },
-                    {
-                        budgetId: budgets[1].budgetId,
-                        id: categoryIdSecondProfile,
-                    }],
-            }));
-            navigateBack();
+            try {
+                await throwingDispatch(addCategoryCombo({
+                    name: name,
+                    categories: [
+                        {
+                            budgetId: budgets[0].budgetId,
+                            id: categoryIdFirstProfile,
+                        },
+                        {
+                            budgetId: budgets[1].budgetId,
+                            id: categoryIdSecondProfile,
+                        }],
+                }));
+                navigateBack();
+            } catch {
+                Alert.alert('Error', 'Could not save. Please try again.');
+            }
         },
-        [categoryIdFirstProfile, categoryIdSecondProfile, dispatch, name, navigateBack, budgets],
+        [categoryIdFirstProfile, categoryIdSecondProfile, throwingDispatch, name, navigateBack, budgets],
     );
 
     const navigationBarAddition = useMemo(

--- a/src/Screens/Settings/CategoryCombos/EditCategoryComboScreen/EditCategoryComboScreen.tsx
+++ b/src/Screens/Settings/CategoryCombos/EditCategoryComboScreen/EditCategoryComboScreen.tsx
@@ -35,8 +35,8 @@ export const EditCategoryComboScreen = ({ navigation, route }: MyStackScreenProp
     const readyToSave = name.length > 0 && categoryIdFirstProfile && categoryIdSecondProfile;
 
     const onSelectDeletion = useCallback(
-        (): void => {
-            dispatch(deleteCategoryCombo(categoryCombo.id));
+        async (): Promise<void> => {
+            await dispatch(deleteCategoryCombo(categoryCombo.id));
             setMenuVisible(false);
             navigateBack();
         },
@@ -60,12 +60,12 @@ export const EditCategoryComboScreen = ({ navigation, route }: MyStackScreenProp
     );
 
     const saveAndNavigate = useCallback(
-        () => {
+        async () => {
             if (!categoryIdFirstProfile || !categoryIdSecondProfile) {
                 throw new Error('Not ready to save yet');
             }
 
-            dispatch(updateCategoryCombo(
+            await dispatch(updateCategoryCombo(
                 {
                     categoryCombo: {
                         id: categoryCombo.id,

--- a/src/Screens/Settings/CategoryCombos/EditCategoryComboScreen/EditCategoryComboScreen.tsx
+++ b/src/Screens/Settings/CategoryCombos/EditCategoryComboScreen/EditCategoryComboScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
+import { Alert } from 'react-native';
 import { Appbar, Menu } from 'react-native-paper';
 import { MyStackScreenProps } from '../../../../Navigation/ScreenParameters';
 import { deleteCategoryCombo, updateCategoryCombo } from '../../../../redux/features/categoryCombos/categoryCombosSlice';
@@ -7,7 +8,7 @@ import { selectProfile } from '../../../../redux/features/profile/profileSlice';
 import { useNavigateBack } from '../../../../Hooks/useNavigateBack';
 import { CategoryComboInputView } from '../CategoryComboInputView';
 import { AppBarMoreMenu } from '../../../../Component/AppBarMoreMenu';
-import { useAppDispatch } from '../../../../Hooks/useAppDispatch';
+import { useThrowingDispatch } from '../../../../Hooks/useThrowingDispatch';
 import { useNavigationSettings } from '../../../../Hooks/useNavigationSettings';
 import { useTheme } from '../../../../Hooks/useTheme';
 
@@ -18,7 +19,7 @@ const SCREEN_TITLE = 'Edit Cat. Combo';
 const ICON_SAVE = 'check';
 
 export const EditCategoryComboScreen = ({ navigation, route }: MyStackScreenProps<ScreenName>) => {
-    const dispatch = useAppDispatch();
+    const throwingDispatch = useThrowingDispatch();
     const { categoryCombo } = route.params;
 
     const profile = useAppSelector(selectProfile);
@@ -36,11 +37,15 @@ export const EditCategoryComboScreen = ({ navigation, route }: MyStackScreenProp
 
     const onSelectDeletion = useCallback(
         async (): Promise<void> => {
-            await dispatch(deleteCategoryCombo(categoryCombo.id));
-            setMenuVisible(false);
-            navigateBack();
+            try {
+                await throwingDispatch(deleteCategoryCombo(categoryCombo.id));
+                setMenuVisible(false);
+                navigateBack();
+            } catch {
+                Alert.alert('Error', 'Could not delete. Please try again.');
+            }
         },
-        [categoryCombo.id, dispatch, navigateBack],
+        [categoryCombo.id, throwingDispatch, navigateBack],
     );
 
     const moreMenu = useMemo(
@@ -65,26 +70,30 @@ export const EditCategoryComboScreen = ({ navigation, route }: MyStackScreenProp
                 throw new Error('Not ready to save yet');
             }
 
-            await dispatch(updateCategoryCombo(
-                {
-                    categoryCombo: {
-                        id: categoryCombo.id,
-                        name: name,
-                        categories: [
-                            {
-                                budgetId: budgets[0].budgetId,
-                                id: categoryIdFirstProfile,
-                            },
-                            {
-                                budgetId: budgets[1].budgetId,
-                                id: categoryIdSecondProfile,
-                            }],
+            try {
+                await throwingDispatch(updateCategoryCombo(
+                    {
+                        categoryCombo: {
+                            id: categoryCombo.id,
+                            name: name,
+                            categories: [
+                                {
+                                    budgetId: budgets[0].budgetId,
+                                    id: categoryIdFirstProfile,
+                                },
+                                {
+                                    budgetId: budgets[1].budgetId,
+                                    id: categoryIdSecondProfile,
+                                }],
+                        },
                     },
-                },
-            ));
-            navigateBack();
+                ));
+                navigateBack();
+            } catch {
+                Alert.alert('Error', 'Could not save. Please try again.');
+            }
         },
-        [categoryCombo.id, categoryIdFirstProfile, categoryIdSecondProfile, dispatch, name, navigateBack, budgets],
+        [categoryCombo.id, categoryIdFirstProfile, categoryIdSecondProfile, throwingDispatch, name, navigateBack, budgets],
     );
 
     const navigationBarAdditions = useMemo(

--- a/src/Screens/Settings/DevelopmentSettingsScreen/DevelopmentSettingsScreen.tsx
+++ b/src/Screens/Settings/DevelopmentSettingsScreen/DevelopmentSettingsScreen.tsx
@@ -1,11 +1,12 @@
 import { MyStackScreenProps } from '../../../Navigation/ScreenParameters';
 import { Button, List } from 'react-native-paper';
 import { useNavigationSettings } from '../../../Hooks/useNavigationSettings';
+import { Alert } from 'react-native';
 import { RefreshControl } from 'react-native-gesture-handler';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import * as Updates from 'expo-updates';
 import { UpdateCheckResult } from 'expo-updates';
-import { useAppDispatch } from '../../../Hooks/useAppDispatch';
+import { useThrowingDispatch } from '../../../Hooks/useThrowingDispatch';
 import { deleteAllCategoryCombos } from '../../../redux/features/categoryCombos/categoryCombosSlice';
 import { deleteProfile } from '../../../redux/features/profile/profileSlice';
 import { CustomScrollView } from '../../../Component/CustomScrollView';
@@ -17,7 +18,7 @@ const SCREEN_TITLE = 'Development Settings';
 export const DevelopmentSettingsScreen = ({ navigation }: MyStackScreenProps<ScreenName>) => {
     const [refreshing, setRefreshing] = useState(false);
     const [latestUpdate, setLatestUpdate] = useState<UpdateCheckResult | undefined>(undefined);
-    const dispatch = useAppDispatch();
+    const throwingDispatch = useThrowingDispatch();
 
     useNavigationSettings({
         title: SCREEN_TITLE,
@@ -114,10 +115,14 @@ export const DevelopmentSettingsScreen = ({ navigation }: MyStackScreenProps<Scr
 
     const onDeleteButtonPress = useCallback(
         async () => {
-            await dispatch(deleteAllCategoryCombos());
-            await dispatch(deleteProfile());
+            try {
+                await throwingDispatch(deleteAllCategoryCombos());
+                await throwingDispatch(deleteProfile());
+            } catch {
+                Alert.alert('Error', 'Could not delete. Please try again.');
+            }
         },
-        [dispatch],
+        [throwingDispatch],
     );
 
     return (

--- a/src/Screens/Settings/DisplaySettingsScreen/ThemeModalPortal.tsx
+++ b/src/Screens/Settings/DisplaySettingsScreen/ThemeModalPortal.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback } from 'react';
+import { Alert } from 'react-native';
 import { RadioButton } from 'react-native-paper';
 import { saveThemeTypeSetting, selectThemeTypeSetting } from '../../../redux/features/displaySettings/displaySettingsSlice';
 import { THEME_TYPE_LABELS, ThemeType } from '../../../redux/features/displaySettings/ThemeType';
 import { useAppSelector } from '../../../Hooks/useAppSelector';
-import { useAppDispatch } from '../../../Hooks/useAppDispatch';
+import { useThrowingDispatch } from '../../../Hooks/useThrowingDispatch';
 import { PortalModal } from '../../../Component/PortalModal';
 
 type Props = {
@@ -12,7 +13,7 @@ type Props = {
 }
 
 export const ThemeModalPortal = (props: Props) => {
-    const dispatch = useAppDispatch();
+    const throwingDispatch = useThrowingDispatch();
     const themeTypeSetting = useAppSelector(selectThemeTypeSetting);
 
     const radioButton = (themeType: ThemeType) => (
@@ -25,9 +26,13 @@ export const ThemeModalPortal = (props: Props) => {
 
     const save = useCallback(
         async (newThemeType: string) => {
-            await dispatch(saveThemeTypeSetting(newThemeType as ThemeType));
+            try {
+                await throwingDispatch(saveThemeTypeSetting(newThemeType as ThemeType));
+            } catch {
+                Alert.alert('Error', 'Could not save. Please try again.');
+            }
         },
-        [dispatch],
+        [throwingDispatch],
     );
 
     return (

--- a/src/Screens/Settings/DisplaySettingsScreen/ThemeModalPortal.tsx
+++ b/src/Screens/Settings/DisplaySettingsScreen/ThemeModalPortal.tsx
@@ -24,7 +24,9 @@ export const ThemeModalPortal = (props: Props) => {
     );
 
     const save = useCallback(
-        (newThemeType: string) => dispatch(saveThemeTypeSetting(newThemeType as ThemeType)),
+        async (newThemeType: string) => {
+            await dispatch(saveThemeTypeSetting(newThemeType as ThemeType));
+        },
         [dispatch],
     );
 

--- a/src/Screens/Settings/Profiles/ProfileScreen/ProfileScreen.tsx
+++ b/src/Screens/Settings/Profiles/ProfileScreen/ProfileScreen.tsx
@@ -27,7 +27,7 @@ export const ProfileScreen = ({ navigation }: MyStackScreenProps<ScreenName>) =>
     const [theme] = useTheme();
 
     const saveAndNavigate = useCallback(async (): Promise<void> => {
-        save();
+        await save();
         navigateBack();
     }, [navigateBack, save]);
 

--- a/src/Screens/Settings/Profiles/ProfileScreen/ProfileScreen.tsx
+++ b/src/Screens/Settings/Profiles/ProfileScreen/ProfileScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
+import { Alert } from 'react-native';
 import { CustomScrollView } from '../../../../Component/CustomScrollView';
 import { MyStackScreenProps } from '../../../../Navigation/ScreenParameters';
 import { BudgetInProfileInputSection } from '../BudgetInProfileInputSection';
@@ -27,8 +28,12 @@ export const ProfileScreen = ({ navigation }: MyStackScreenProps<ScreenName>) =>
     const [theme] = useTheme();
 
     const saveAndNavigate = useCallback(async (): Promise<void> => {
-        await save();
-        navigateBack();
+        try {
+            await save();
+            navigateBack();
+        } catch {
+            Alert.alert('Error', 'Could not save. Please try again.');
+        }
     }, [navigateBack, save]);
 
     const navigationBarAddition = useMemo(

--- a/src/Screens/SplittingScreen/SplittingScreen.tsx
+++ b/src/Screens/SplittingScreen/SplittingScreen.tsx
@@ -128,6 +128,13 @@ const SplittingScreenContent = ({ navigation }: MyStackScreenProps<ScreenName>) 
 
     const navigateToAmountsScreen = useCallback(
         (): void => {
+            // Trigger fetches again if they failed before
+            if (payerCategoriesFetchStatus === LoadingStatus.ERROR) {
+                dispatch(fetchCategoryGroups({ accessToken: accessToken, budgetId: payerBudgetInProfile.budgetId }));
+            }
+            if (debtorCategoriesFetchStatus === LoadingStatus.ERROR) {
+                dispatch(fetchCategoryGroups({ accessToken: accessToken, budgetId: debtorBudgetInProfile.budgetId }));
+            }
             navigation.navigate(
                 ScreenNames.AMOUNTS_SCREEN,
                 {
@@ -151,9 +158,10 @@ const SplittingScreenContent = ({ navigation }: MyStackScreenProps<ScreenName>) 
             );
         },
         [
-            date, debtorBudgetInProfile.budgetId, debtorBudgetInProfile.debtorAccountId,
-            memo, navigation, payeeName, payerAccountID, payerBudgetInProfile.budgetId,
-            payerBudgetInProfile.debtorAccountId, payerTransferAccount.transferPayeeID, totalAmount,
+            accessToken, date, debtorBudgetInProfile.budgetId, debtorBudgetInProfile.debtorAccountId,
+            debtorCategoriesFetchStatus, dispatch, memo, navigation, payeeName, payerAccountID,
+            payerBudgetInProfile.budgetId, payerBudgetInProfile.debtorAccountId,
+            payerCategoriesFetchStatus, payerTransferAccount.transferPayeeID, totalAmount,
         ],
     );
 

--- a/src/redux/features/accessToken/accessTokenSlice.ts
+++ b/src/redux/features/accessToken/accessTokenSlice.ts
@@ -65,20 +65,20 @@ export const accessTokenSlice = createSlice({
                 };
             })
             .addCase(saveAccessToken.pending, (state) => {
-                state.fetchStatus = {
+                state.saveStatus = {
                     status: LoadingStatus.LOADING,
                     error: null,
                 };
             })
             .addCase(saveAccessToken.fulfilled, (state, action) => {
-                state.fetchStatus = {
+                state.saveStatus = {
                     status: LoadingStatus.SUCCESSFUL,
                     error: null,
                 };
                 state.accessToken = action.payload;
             })
             .addCase(saveAccessToken.rejected, (state, action) => {
-                state.fetchStatus = {
+                state.saveStatus = {
                     status: LoadingStatus.ERROR,
                     error: action.error,
                 };


### PR DESCRIPTION
- **Fix fire-and-forget dispatches** — all save operations now `await` the dispatch before navigating, ensuring the operation completes before the user leaves the screen
- **Add `useThrowingDispatch` hook** — wraps `useAppDispatch` and converts rejected thunk actions into thrown errors, allowing call sites to use normal `try/catch` instead of manually inspecting action results
- **Surface save errors to the user** — all save screens (`AccessTokenScreen`, `CreateCategoryComboScreen`, `EditCategoryComboScreen`, `ProfileScreen`, `ThemeModalPortal`, `DevelopmentSettingsScreen`) now show an `Alert` on failure
- **Handle initial fetch errors** — `useInitialFetchStatus` now aggregates the 4 local SecureStore fetches into a `localStatus` value; any failure returns `InitialFetchStatus.ERROR` which throws to the `ErrorBoundary`; `fetchBudgets` failure routes to the setup flow instead of getting stuck on a white screen
- **Handle category fetch errors** — `SplittingScreen` retries failed category fetches before navigating to `AmountsScreen`; if still failing after the retry, `AmountsScreen` and `CategoryComboSettingsScreen` throw to the `ErrorBoundary`
- **Fix `accessTokenSlice` bug** — `saveAccessToken` cases were incorrectly updating `fetchStatus` instead of `saveStatus`