### PR TITLE
Detect YNAB account switch and reset data

### DIFF
--- a/src/Hooks/useConnectionTest.ts
+++ b/src/Hooks/useConnectionTest.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
-import { API } from 'ynab';
 import { LoadingStatus } from '../Helper/LoadingStatus';
+import { getUserId } from '../YnabApi/YnabApiWrapper';
 
 export type ConnectionStatus = {
     status: LoadingStatus,
@@ -17,7 +17,7 @@ export const useConnectionTest = (): [ConnectionStatus, (accessToken: string) =>
         setConnectionStatus({ status: LoadingStatus.LOADING });
 
         try {
-            await new API(accessToken).user.getUser();
+            await getUserId(accessToken);
             setConnectionStatus({ status: LoadingStatus.SUCCESSFUL });
         } catch (error: any) {
             setConnectionStatus({

--- a/src/Screens/Settings/AccessTokenScreen/AccessTokenScreen.tsx
+++ b/src/Screens/Settings/AccessTokenScreen/AccessTokenScreen.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Alert, View } from 'react-native';
 import { Appbar, Button } from 'react-native-paper';
-import { API } from 'ynab';
 import { MyStackScreenProps } from '../../../Navigation/ScreenParameters';
+import { getUserId } from '../../../YnabApi/YnabApiWrapper';
 import { saveAccessToken, selectAccessToken } from '../../../redux/features/accessToken/accessTokenSlice';
 import { deleteProfile, saveProfile, selectProfile } from '../../../redux/features/profile/profileSlice';
 import { deleteAllCategoryCombos } from '../../../redux/features/categoryCombos/categoryCombosSlice';
@@ -35,8 +35,7 @@ export const AccessTokenScreen = ({ navigation }: MyStackScreenProps<ScreenName>
     const onSavePress = useCallback(async () => {
         let newUserId: string;
         try {
-            const response = await new API(enteredToken).user.getUser();
-            newUserId = response.data.user.id;
+            newUserId = await getUserId(enteredToken);
         } catch {
             Alert.alert('Invalid Token', 'Could not connect with this token. Please test the connection first.');
             return;

--- a/src/Screens/Settings/AccessTokenScreen/AccessTokenScreen.tsx
+++ b/src/Screens/Settings/AccessTokenScreen/AccessTokenScreen.tsx
@@ -1,8 +1,11 @@
 import { useMemo, useState } from 'react';
 import { Alert, View } from 'react-native';
 import { Appbar, Button } from 'react-native-paper';
+import { API } from 'ynab';
 import { MyStackScreenProps } from '../../../Navigation/ScreenParameters';
 import { saveAccessToken, selectAccessToken } from '../../../redux/features/accessToken/accessTokenSlice';
+import { deleteProfile, saveProfile, selectProfile } from '../../../redux/features/profile/profileSlice';
+import { deleteAllCategoryCombos } from '../../../redux/features/categoryCombos/categoryCombosSlice';
 import { useAppSelector } from '../../../Hooks/useAppSelector';
 import { LoadingStatus } from '../../../Helper/LoadingStatus';
 import { AccessTokenInput } from './AccessTokenInput';
@@ -23,6 +26,7 @@ const ICON_CONNECTION_ERROR = 'alert-circle';
 export const AccessTokenScreen = ({ navigation }: MyStackScreenProps<ScreenName>) => {
     const throwingDispatch = useThrowingDispatch();
     const accessToken = useAppSelector(selectAccessToken);
+    const profile = useAppSelector(selectProfile);
     const [enteredToken, setEnteredToken] = useState<string>(accessToken);
     const [connectionStatus, testConnection] = useConnectionTest();
     const [navigateBack] = useNavigateBack(navigation);
@@ -34,8 +38,45 @@ export const AccessTokenScreen = ({ navigation }: MyStackScreenProps<ScreenName>
                 icon={ICON_SAVE}
                 iconColor={theme.colors.onPrimary}
                 onPress={async () => {
+                    let newUserId: string;
+                    try {
+                        const response = await new API(enteredToken).user.getUser();
+                        newUserId = response.data.user.id;
+                    } catch {
+                        Alert.alert('Invalid Token', 'Could not connect with this token. Please test the connection first.');
+                        return;
+                    }
+
+                    if (profile?.ynabUserId !== undefined && newUserId !== profile.ynabUserId) {
+                        Alert.alert(
+                            'Different YNAB Account',
+                            'This token belongs to a different YNAB account. All profiles and category combos will be deleted. Continue?',
+                            [
+                                { text: 'Cancel', style: 'cancel' },
+                                {
+                                    text: 'Continue',
+                                    style: 'destructive',
+                                    onPress: async () => {
+                                        try {
+                                            await throwingDispatch(deleteAllCategoryCombos());
+                                            await throwingDispatch(deleteProfile());
+                                            await throwingDispatch(saveAccessToken(enteredToken));
+                                            navigateBack();
+                                        } catch {
+                                            Alert.alert('Error', 'Could not save. Please try again.');
+                                        }
+                                    },
+                                },
+                            ],
+                        );
+                        return;
+                    }
+
                     try {
                         await throwingDispatch(saveAccessToken(enteredToken));
+                        if (profile !== null) {
+                            await throwingDispatch(saveProfile({ ...profile, ynabUserId: newUserId }));
+                        }
                         navigateBack();
                     } catch {
                         Alert.alert('Error', 'Could not save. Please try again.');
@@ -43,7 +84,7 @@ export const AccessTokenScreen = ({ navigation }: MyStackScreenProps<ScreenName>
                 }}
             />
         ),
-        [throwingDispatch, enteredToken, navigateBack, theme],
+        [throwingDispatch, enteredToken, profile, navigateBack, theme],
     );
 
     useNavigationSettings({

--- a/src/Screens/Settings/AccessTokenScreen/AccessTokenScreen.tsx
+++ b/src/Screens/Settings/AccessTokenScreen/AccessTokenScreen.tsx
@@ -45,7 +45,7 @@ export const AccessTokenScreen = ({ navigation }: MyStackScreenProps<ScreenName>
         if (profile?.ynabUserId !== undefined && newUserId !== profile.ynabUserId) {
             Alert.alert(
                 'Different YNAB Account',
-                'This token belongs to a different YNAB account. All profiles and category combos will be deleted. Continue?',
+                'This token belongs to a different YNAB account. The profile and all category combos will be deleted. Continue?',
                 [
                     { text: 'Cancel', style: 'cancel' },
                     {

--- a/src/Screens/Settings/AccessTokenScreen/AccessTokenScreen.tsx
+++ b/src/Screens/Settings/AccessTokenScreen/AccessTokenScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Alert, View } from 'react-native';
 import { Appbar, Button } from 'react-native-paper';
 import { API } from 'ynab';
@@ -32,59 +32,61 @@ export const AccessTokenScreen = ({ navigation }: MyStackScreenProps<ScreenName>
     const [navigateBack] = useNavigateBack(navigation);
     const [theme] = useTheme();
 
+    const onSavePress = useCallback(async () => {
+        let newUserId: string;
+        try {
+            const response = await new API(enteredToken).user.getUser();
+            newUserId = response.data.user.id;
+        } catch {
+            Alert.alert('Invalid Token', 'Could not connect with this token. Please test the connection first.');
+            return;
+        }
+
+        if (profile?.ynabUserId !== undefined && newUserId !== profile.ynabUserId) {
+            Alert.alert(
+                'Different YNAB Account',
+                'This token belongs to a different YNAB account. All profiles and category combos will be deleted. Continue?',
+                [
+                    { text: 'Cancel', style: 'cancel' },
+                    {
+                        text: 'Continue',
+                        style: 'destructive',
+                        onPress: async () => {
+                            try {
+                                await throwingDispatch(deleteAllCategoryCombos());
+                                await throwingDispatch(deleteProfile());
+                                await throwingDispatch(saveAccessToken(enteredToken));
+                                navigateBack();
+                            } catch {
+                                Alert.alert('Error', 'Could not save. Please try again.');
+                            }
+                        },
+                    },
+                ],
+            );
+            return;
+        }
+
+        try {
+            await throwingDispatch(saveAccessToken(enteredToken));
+            if (profile !== null) {
+                await throwingDispatch(saveProfile({ ...profile, ynabUserId: newUserId }));
+            }
+            navigateBack();
+        } catch {
+            Alert.alert('Error', 'Could not save. Please try again.');
+        }
+    }, [throwingDispatch, enteredToken, profile, navigateBack]);
+
     const navigationBarAddition = useMemo(
         () => (
             <Appbar.Action
                 icon={ICON_SAVE}
                 iconColor={theme.colors.onPrimary}
-                onPress={async () => {
-                    let newUserId: string;
-                    try {
-                        const response = await new API(enteredToken).user.getUser();
-                        newUserId = response.data.user.id;
-                    } catch {
-                        Alert.alert('Invalid Token', 'Could not connect with this token. Please test the connection first.');
-                        return;
-                    }
-
-                    if (profile?.ynabUserId !== undefined && newUserId !== profile.ynabUserId) {
-                        Alert.alert(
-                            'Different YNAB Account',
-                            'This token belongs to a different YNAB account. All profiles and category combos will be deleted. Continue?',
-                            [
-                                { text: 'Cancel', style: 'cancel' },
-                                {
-                                    text: 'Continue',
-                                    style: 'destructive',
-                                    onPress: async () => {
-                                        try {
-                                            await throwingDispatch(deleteAllCategoryCombos());
-                                            await throwingDispatch(deleteProfile());
-                                            await throwingDispatch(saveAccessToken(enteredToken));
-                                            navigateBack();
-                                        } catch {
-                                            Alert.alert('Error', 'Could not save. Please try again.');
-                                        }
-                                    },
-                                },
-                            ],
-                        );
-                        return;
-                    }
-
-                    try {
-                        await throwingDispatch(saveAccessToken(enteredToken));
-                        if (profile !== null) {
-                            await throwingDispatch(saveProfile({ ...profile, ynabUserId: newUserId }));
-                        }
-                        navigateBack();
-                    } catch {
-                        Alert.alert('Error', 'Could not save. Please try again.');
-                    }
-                }}
+                onPress={onSavePress}
             />
         ),
-        [throwingDispatch, enteredToken, profile, navigateBack, theme],
+        [onSavePress, theme],
     );
 
     useNavigationSettings({

--- a/src/Screens/Settings/Profiles/ProfileScreen/ProfileScreen.tsx
+++ b/src/Screens/Settings/Profiles/ProfileScreen/ProfileScreen.tsx
@@ -60,13 +60,14 @@ export const ProfileScreen = ({ navigation }: MyStackScreenProps<ScreenName>) =>
             }
             const profile: Profile = {
                 budgets: [finalizeBudget(budgetInProfile1), finalizeBudget(budgetInProfile2)],
+                ynabUserId: savedProfile?.ynabUserId,
             };
             await throwingDispatch(saveProfile(profile));
             navigateBack();
         } catch {
             Alert.alert('Error', 'Could not save. Please try again.');
         }
-    }, [budgetIdsChanged, budgetInProfile1, budgetInProfile2, categoryCombos.length, navigateBack, throwingDispatch]);
+    }, [budgetIdsChanged, budgetInProfile1, budgetInProfile2, categoryCombos.length, navigateBack, savedProfile?.ynabUserId, throwingDispatch]);
 
     const saveAndNavigate = useCallback((): void => {
         if (budgetIdsChanged && categoryCombos.length > 0) {

--- a/src/YnabApi/YnabApiWrapper.ts
+++ b/src/YnabApi/YnabApiWrapper.ts
@@ -15,6 +15,12 @@ export type Budget = {
     accounts: Array<Account>;
 }
 
+export const getUserId = async (apiKey: string): Promise<string> => {
+    const ynabAPI = new API(apiKey);
+    const response = await ynabAPI.user.getUser();
+    return response.data.user.id;
+};
+
 const getCategoriesGroupedByCategoryGroup = async (apiKey: string, budgetId: string): Promise<CategoryGroupWithCategories[]> => {
     const ynabAPI = new API(apiKey);
     const response = await ynabAPI.categories.getCategories(budgetId);

--- a/src/redux/features/profile/profileSlice.ts
+++ b/src/redux/features/profile/profileSlice.ts
@@ -13,7 +13,8 @@ export type BudgetInProfile = {
 }
 
 export type Profile = {
-    budgets: [BudgetInProfile, BudgetInProfile]
+    budgets: [BudgetInProfile, BudgetInProfile],
+    ynabUserId?: string,
 }
 
 type ProfileState = {


### PR DESCRIPTION
When a user changes their access token to one belonging to a different YNAB account, all locally stored data (profile, category combos) becomes invalid since budget/account/category IDs are account-specific. This PR detects that situation and prompts the user to reset before saving.

**How it works**

- `ynabUserId` is added as an optional field on `Profile`, stored alongside the budget configuration it belongs to
- When saving a new token, `getUserId` is called against the YNAB API. If the profile already has a `ynabUserId` that differs from the new token's, a destructive confirmation dialog is shown before wiping the profile and category combos
- On a normal (same-account) save, the profile is updated with the `ynabUserId` so future switches can be detected
- `ProfileScreen` preserves `ynabUserId` when the profile is edited so it isn't lost on save

**Notes**

- Existing users won't have `ynabUserId` in their profile after updating — detection is dormant until they next save their token. This is safe: it means no false resets, just a missed detection on the very first save after the update
- `getUserId` was added to `YnabApiWrapper` and replaces the raw `new API(...).user.getUser()` calls in both `AccessTokenScreen` and `useConnectionTest`

Fixes https://github.com/ConjuringCoffee/transaction-splitter/issues/127