### PR TITLE
Use currency symbol from YNAB budget settings

### DIFF
--- a/src/Hooks/useAmountConversion.ts
+++ b/src/Hooks/useAmountConversion.ts
@@ -19,7 +19,7 @@ export const useAmountConversion = (): Return => {
     );
 
     const convertNumberToText = useCallback(
-        (number: number) => number.toString().replace('.', numberFormatSettings.decimalSeparator),
+        (number: number) => number.toFixed(2).replace('.', numberFormatSettings.decimalSeparator),
         [numberFormatSettings],
     );
 

--- a/src/Hooks/useCurrencyFormat.ts
+++ b/src/Hooks/useCurrencyFormat.ts
@@ -1,0 +1,15 @@
+import { useCallback } from 'react';
+import { selectBudgetCurrencySymbol, selectBudgetSymbolFirst } from '../redux/features/ynab/ynabSlice';
+import { useAppSelector } from './useAppSelector';
+
+export const useCurrencyFormat = (budgetId: string) => {
+    const currencySymbol = useAppSelector((state) => selectBudgetCurrencySymbol(state, budgetId));
+    const symbolFirst = useAppSelector((state) => selectBudgetSymbolFirst(state, budgetId));
+
+    const formatAmount = useCallback(
+        (amount: string) => symbolFirst ? `${currencySymbol}${amount}` : `${amount}${currencySymbol}`,
+        [currencySymbol, symbolFirst],
+    );
+
+    return { formatAmount, currencySymbol };
+};

--- a/src/Screens/AmountsScreen/AmountView.tsx
+++ b/src/Screens/AmountsScreen/AmountView.tsx
@@ -100,6 +100,7 @@ export const AmountView = <T extends keyof StackParameterList>({
                         value={amountEntry.amountText}
                         setValue={(text) => updateAmountEntry({ amountText: text })}
                         navigation={navigation}
+                        budgetId={payerBudgetId}
                     />
                 </View>
                 <IconButton

--- a/src/Screens/AmountsScreen/AmountsScreen.tsx
+++ b/src/Screens/AmountsScreen/AmountsScreen.tsx
@@ -15,6 +15,7 @@ import { selectAccessToken } from '../../redux/features/accessToken/accessTokenS
 import { Appbar, Button, Text } from 'react-native-paper';
 import { useAmountConversion } from '../../Hooks/useAmountConversion';
 import { useAppDispatch } from '../../Hooks/useAppDispatch';
+import { useCurrencyFormat } from '../../Hooks/useCurrencyFormat';
 import { useNavigationSettings } from '../../Hooks/useNavigationSettings';
 import { useTheme } from '../../Hooks/useTheme';
 import { isSplitPercentInvalid } from '../../Helper/SplitPercentHelper';
@@ -44,6 +45,7 @@ export const AmountsScreen = ({ navigation, route }: MyStackScreenProps<ScreenNa
     const basicData = route.params.basicData;
     const payerBudgetId = basicData.payer.budgetId;
     const debtorBudgetId = basicData.debtor.budgetId;
+    const { formatAmount } = useCurrencyFormat(payerBudgetId);
 
     const payerCategoriesFetchStatus = useAppSelector((state) => selectCategoriesFetchStatus(state, payerBudgetId));
     const debtorCategoriesFetchStatus = useAppSelector((state) => selectCategoriesFetchStatus(state, debtorBudgetId));
@@ -226,7 +228,7 @@ export const AmountsScreen = ({ navigation, route }: MyStackScreenProps<ScreenNa
             </CustomScrollView>
             <View style={{ padding: theme.cardPadding, gap: theme.spacing }}>
                 <Text variant='bodyMedium' style={{ textAlign: 'center' }}>
-                    {`Remaining: ${convertNumberToText(remainingAmount)}€`}
+                    {`Remaining: ${formatAmount(convertNumberToText(remainingAmount))}`}
                 </Text>
                 <View style={{ flexDirection: 'row', gap: theme.spacing }}>
                     <Button

--- a/src/Screens/AmountsScreen/SubAmountInput.tsx
+++ b/src/Screens/AmountsScreen/SubAmountInput.tsx
@@ -3,17 +3,20 @@ import { TextInput } from 'react-native-paper';
 import { MyStackNavigationProp, StackParameterList } from '../../Navigation/ScreenParameters';
 import { ScreenNames } from '../../Navigation/ScreenNames';
 import { useAmountConversion } from '../../Hooks/useAmountConversion';
+import { useCurrencyFormat } from '../../Hooks/useCurrencyFormat';
 
 type Props<T extends keyof StackParameterList> = {
     value: string,
     setValue: (newValue: string) => void,
     navigation: MyStackNavigationProp<T>,
+    budgetId: string,
 }
 
 const ICON_CALCULATOR = 'calculator-variant';
 
-export const SubAmountInput = <T extends keyof StackParameterList>({ value, setValue, navigation }: Props<T>) => {
+export const SubAmountInput = <T extends keyof StackParameterList>({ value, setValue, navigation, budgetId }: Props<T>) => {
     const [convertTextToNumber, convertNumberToText] = useAmountConversion();
+    const { currencySymbol } = useCurrencyFormat(budgetId);
 
     const [previousCalculations, setPreviousCalculations] = useState<Array<string>>([]);
 
@@ -45,7 +48,7 @@ export const SubAmountInput = <T extends keyof StackParameterList>({ value, setV
 
     return (
         <TextInput
-            placeholder='€'
+            placeholder={currencySymbol}
             value={value}
             error={!isValid}
             onChangeText={setValue}

--- a/src/Screens/SaveScreen/SaveTransactionListSection.tsx
+++ b/src/Screens/SaveScreen/SaveTransactionListSection.tsx
@@ -9,6 +9,7 @@ import { useAppSelector } from '../../Hooks/useAppSelector';
 import { SubTransactionsDataTable } from './SubTransactionsDataTable';
 import { MultiLineTextDataTableCellView } from './MultiLineTextDataTableCellView';
 import { useAmountConversion } from '../../Hooks/useAmountConversion';
+import { useCurrencyFormat } from '../../Hooks/useCurrencyFormat';
 import { useTheme } from '../../Hooks/useTheme';
 import { CardSurface } from '../../Component/CardSurface';
 
@@ -39,6 +40,7 @@ const SaveStatusIndicator = ({ saveStatus }: { saveStatus: LoadingStatus }) => {
 export const SaveTransactionListSection = (props: Props) => {
     const [theme] = useTheme();
     const [, convertNumberToText] = useAmountConversion();
+    const { formatAmount } = useCurrencyFormat(props.budgetId);
     const [detailsExpanded, setDetailsExpanded] = useState<boolean>(true);
     const [subTransactionsExpanded, setSubTransactionsExpanded] = useState<boolean>(true);
 
@@ -47,7 +49,7 @@ export const SaveTransactionListSection = (props: Props) => {
 
     const accountName = budget.accounts.find((account) => account.id === props.saveTransaction.account_id)?.name;
     const amountHuman = convertApiAmountToHumanAmount(props.saveTransaction.amount);
-    const amountText = convertNumberToText(amountHuman);
+    const amountText = formatAmount(convertNumberToText(amountHuman));
 
     const toggleDetailsExpanded = useCallback(
         (): void => setDetailsExpanded(!detailsExpanded),

--- a/src/Screens/SaveScreen/SubTransactionDataTableRow.tsx
+++ b/src/Screens/SaveScreen/SubTransactionDataTableRow.tsx
@@ -3,6 +3,7 @@ import { DataTable } from 'react-native-paper';
 import { SaveSubTransaction } from 'ynab';
 import { convertApiAmountToHumanAmount } from '../../Helper/AmountHelper';
 import { useAmountConversion } from '../../Hooks/useAmountConversion';
+import { useCurrencyFormat } from '../../Hooks/useCurrencyFormat';
 import { selectActiveAccounts, selectCategories } from '../../redux/features/ynab/ynabSlice';
 import { useAppSelector } from '../../Hooks/useAppSelector';
 import { MemoDataTableCell } from './MemoDataTableCell';
@@ -19,6 +20,7 @@ export const SubTransactionDataTableRow = ({ budgetId, subTransaction, displayMe
     const categories = useAppSelector((state) => selectCategories(state, budgetId));
     const accounts = useAppSelector((state) => selectActiveAccounts(state, budgetId));
     const [, convertNumberToText] = useAmountConversion();
+    const { formatAmount } = useCurrencyFormat(budgetId);
 
     const targetName = useMemo(() => {
         let result: string | undefined = undefined;
@@ -37,7 +39,7 @@ export const SubTransactionDataTableRow = ({ budgetId, subTransaction, displayMe
     }, [subTransaction, categories, accounts]);
 
     const humanAmount = convertApiAmountToHumanAmount(subTransaction.amount);
-    const humanAmountText = convertNumberToText(humanAmount);
+    const humanAmountText = formatAmount(convertNumberToText(humanAmount));
 
     return (
         <DataTable.Row>

--- a/src/Screens/SplittingScreen/SplittingScreen.tsx
+++ b/src/Screens/SplittingScreen/SplittingScreen.tsx
@@ -183,6 +183,7 @@ const SplittingScreenContent = ({ navigation }: MyStackScreenProps<ScreenName>) 
             <TotalAmountInput
                 value={totalAmountText}
                 setValue={setTotalAmountText}
+                budgetId={payerBudgetInProfile.budgetId}
             />
             <CustomScrollView>
                 <View style={{ gap: theme.spacing }}>

--- a/src/Screens/SplittingScreen/TotalAmountInput.tsx
+++ b/src/Screens/SplittingScreen/TotalAmountInput.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useRef } from 'react';
 import { Pressable, StyleSheet, TextInput, View } from 'react-native';
 import { Text } from 'react-native-paper';
 import { useAmountConversion } from '../../Hooks/useAmountConversion';
+import { useCurrencyFormat } from '../../Hooks/useCurrencyFormat';
 import { useTheme } from '../../Hooks/useTheme';
 
 const FONT_SIZE = 40;
@@ -9,11 +10,13 @@ const FONT_SIZE = 40;
 type Props = {
     value: string,
     setValue: (newValue: string) => void,
+    budgetId: string,
 }
 
-export const TotalAmountInput = ({ value, setValue }: Props) => {
+export const TotalAmountInput = ({ value, setValue, budgetId }: Props) => {
     const [convertTextToNumber] = useAmountConversion();
     const [theme] = useTheme();
+    const { formatAmount } = useCurrencyFormat(budgetId);
     const inputRef = useRef<TextInput>(null);
 
     const isValid = useMemo(
@@ -29,7 +32,7 @@ export const TotalAmountInput = ({ value, setValue }: Props) => {
                 onPress={() => inputRef.current?.focus()}
             >
                 <Text style={[{ fontSize: FONT_SIZE }, !isValid && { color: theme.colors.error }]}>
-                    {`-${value || '0'}€`}
+                    {`-${formatAmount(value || '0')}`}
                 </Text>
                 <TextInput
                     ref={inputRef}

--- a/src/YnabApi/YnabApiWrapper.ts
+++ b/src/YnabApi/YnabApiWrapper.ts
@@ -13,6 +13,8 @@ export type Budget = {
     id: string;
     name: string;
     accounts: Array<Account>;
+    currencySymbol: string;
+    symbolFirst: boolean;
 }
 
 export const getUserId = async (apiKey: string): Promise<string> => {
@@ -46,10 +48,16 @@ export const getBudgetsWithAccountsFromApi = async (apiKey: string): Promise<Bud
                 };
             });
         }
+        if (!budgetSummary.currency_format) {
+            throw new Error(`Budget ${budgetSummary.name} has no currency format`);
+        }
+
         return {
             id: budgetSummary.id,
             name: budgetSummary.name,
             accounts: accounts,
+            currencySymbol: budgetSummary.currency_format.currency_symbol,
+            symbolFirst: budgetSummary.currency_format.symbol_first,
         };
     });
 };

--- a/src/redux/features/ynab/ynabSlice.ts
+++ b/src/redux/features/ynab/ynabSlice.ts
@@ -169,6 +169,12 @@ export const selectCategories = (state: RootState, budgetId: string): { [categor
     return state.ynab.categoryGroups[budgetId].categories;
 };
 
+export const selectBudgetCurrencySymbol = (state: RootState, budgetId: string): string =>
+    selectBudgetById(state, budgetId).currencySymbol;
+
+export const selectBudgetSymbolFirst = (state: RootState, budgetId: string): boolean =>
+    selectBudgetById(state, budgetId).symbolFirst;
+
 export const selectCategoryGroups = (state: RootState, budgetId: string): { [categoryGroupId: string]: CategoryGroup } => {
     return state.ynab.categoryGroups[budgetId].groups;
 };


### PR DESCRIPTION
## Summary

- Replace the hardcoded `€` symbol with the currency symbol configured in the YNAB budget settings, respecting whether the symbol appears before or after the amount (`symbolFirst`)
- Amounts are now always formatted with exactly two decimal places

## Changes

**Data layer**
- Added `currencySymbol` and `symbolFirst` to the `Budget` type, extracted from `currency_format` in the YNAB API response (throws if absent rather than silently defaulting)
- Added `selectBudgetCurrencySymbol` and `selectBudgetSymbolFirst` selectors to `ynabSlice`

**`useCurrencyFormat` hook** (new)
- Accepts a `budgetId`, reads the currency fields from Redux, and returns a `formatAmount(text)` function that handles symbol placement (`symbolFirst`) and the bare `currencySymbol` for placeholders

**Two decimal places**
- `convertNumberToText` in `useAmountConversion` now uses `toFixed(2)` instead of `toString()`, so all display sites consistently show two decimal places

**UI**
- `TotalAmountInput` — accepts `budgetId`, uses `useCurrencyFormat` to format the large total display
- `SubAmountInput` — accepts `budgetId`, uses `currencySymbol` as the input placeholder
- `AmountsScreen` — uses `useCurrencyFormat(payerBudgetId)` for the "Remaining" label
- `SaveTransactionListSection` — uses `useCurrencyFormat` for the total amount row
- `SubTransactionDataTableRow` — uses `useCurrencyFormat` for each subtransaction amount cell