### PR TITLE
Add approval toggle to transaction creation

### DIFF
--- a/src/Navigation/ScreenParameters.ts
+++ b/src/Navigation/ScreenParameters.ts
@@ -17,7 +17,8 @@ type BasicData = {
     payeeName: string,
     date: string,
     memo: string
-    totalAmount: number
+    totalAmount: number,
+    approved: boolean
 }
 
 type StackParameterList = {

--- a/src/Screens/SaveScreen/SaveTransactionListSection.tsx
+++ b/src/Screens/SaveScreen/SaveTransactionListSection.tsx
@@ -103,6 +103,10 @@ export const SaveTransactionListSection = (props: Props) => {
                             <DataTable.Cell>Memo</DataTable.Cell>
                             <MultiLineTextDataTableCellView text={props.memo} />
                         </DataTable.Row>
+                        <DataTable.Row>
+                            <DataTable.Cell>Approved</DataTable.Cell>
+                            <DataTable.Cell>{props.saveTransaction.approved ? 'Yes' : 'No'}</DataTable.Cell>
+                        </DataTable.Row>
                     </DataTable>
                 </List.Accordion>
                 {props.saveTransaction.subtransactions

--- a/src/Screens/SplittingScreen/SplittingScreen.tsx
+++ b/src/Screens/SplittingScreen/SplittingScreen.tsx
@@ -3,7 +3,7 @@ import { Account } from '../../YnabApi/YnabApiWrapper';
 import { BudgetInProfile, selectProfile } from '../../redux/features/profile/profileSlice';
 import { MyStackScreenProps } from '../../Navigation/ScreenParameters';
 import { ScreenNames } from '../../Navigation/ScreenNames';
-import { Appbar, Button, Surface, Text, TextInput } from 'react-native-paper';
+import { Appbar, Button, Surface, Switch, Text, TextInput } from 'react-native-paper';
 import { useTheme } from '../../Hooks/useTheme';
 import { useAppSelector } from '../../Hooks/useAppSelector';
 import { InitialFetchStatus, useInitialFetchStatus } from '../../Hooks/useInitialFetchStatus';
@@ -60,6 +60,7 @@ const SplittingScreenContent = ({ navigation }: MyStackScreenProps<ScreenName>) 
     const [totalAmountText, setTotalAmountText] = useState<string>('');
     const [date, setDate] = useState<Date>(new Date());
     const [memo, setMemo] = useState<string>('[Generated]');
+    const [approved, setApproved] = useState<boolean>(true);
 
     const payerBudgetInProfile = profile.budgets[payerBudgetIndex];
     const debtorBudgetInProfile = profile.budgets[1 - payerBudgetIndex];
@@ -166,12 +167,13 @@ const SplittingScreenContent = ({ navigation }: MyStackScreenProps<ScreenName>) 
                         date: toIsoDateString(date),
                         memo,
                         totalAmount,
+                        approved,
                     },
                 },
             );
         },
         [
-            accessToken, date, debtorBudgetInProfile.budgetId, debtorBudgetInProfile.debtorAccountId,
+            accessToken, approved, date, debtorBudgetInProfile.budgetId, debtorBudgetInProfile.debtorAccountId,
             debtorCategoriesFetchStatus, dispatch, memo, navigation, payeeName, payerAccountID,
             payerBudgetInProfile.budgetId, payerBudgetInProfile.debtorAccountId,
             payerCategoriesFetchStatus, payerTransferAccount.transferPayeeID, totalAmount,
@@ -231,6 +233,13 @@ const SplittingScreenContent = ({ navigation }: MyStackScreenProps<ScreenName>) 
                             value={memo}
                             onChangeText={setMemo}
                         />
+                        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+                            <Text variant='bodyLarge'>Approved</Text>
+                            <Switch
+                                value={approved}
+                                onValueChange={setApproved}
+                            />
+                        </View>
                     </Surface>
                 </View>
             </CustomScrollView>

--- a/src/YnabApi/BuildSaveTransactions.ts
+++ b/src/YnabApi/BuildSaveTransactions.ts
@@ -38,7 +38,7 @@ const buildSaveTransactions = (amountEntries: AmountEntry[], basicData: BasicDat
         payee_name: basicData.payeeName,
         memo: basicData.memo,
         subtransactions: [],
-        approved: true,
+        approved: basicData.approved,
     };
 
     const debtorSaveTransaction: ynab.SaveTransaction = {
@@ -48,7 +48,7 @@ const buildSaveTransactions = (amountEntries: AmountEntry[], basicData: BasicDat
         payee_name: basicData.payeeName,
         memo: basicData.memo,
         subtransactions: [],
-        approved: true,
+        approved: basicData.approved,
     };
 
     amountEntries.forEach((amountEntry) => {


### PR DESCRIPTION
Previously, all transactions created by the app were hardcoded to `approved: true`. This adds a toggle to the Split Transaction screen so the user can choose whether the transactions should be approved on creation or left for manual review in YNAB.

**Changes:**
- `BasicData` now carries an `approved: boolean` field (default `true`) through the screen stack
- The Details card on the Split Transaction screen has a new "Approved" switch
- Both payer and debtor transactions are created with `approved` from `BasicData` instead of hardcoded `true`
- The Save screen review shows "Approved: Yes/No" for each transaction