### PR TITLE
Redesign calculator screen

### DIFF
--- a/src/Screens/CalculatorScreen/CalculatorKeyboard.tsx
+++ b/src/Screens/CalculatorScreen/CalculatorKeyboard.tsx
@@ -23,7 +23,7 @@ export const CalculatorKeyboard = (props: Props) => {
     const [theme] = useTheme();
 
     return (
-        <View style={[styles.mainLayout, { borderTopColor: theme.colors.outlineVariant }]}>
+        <View style={[styles.mainLayout, { borderTopColor: theme.colors.outlineVariant, backgroundColor: theme.colors.elevation.level1 }]}>
             <View style={styles.numberLayout}>
                 <View style={styles.numberRow}>
                     <KeyboardButton

--- a/src/Screens/CalculatorScreen/CalculatorKeyboard.tsx
+++ b/src/Screens/CalculatorScreen/CalculatorKeyboard.tsx
@@ -21,11 +21,21 @@ type Props = {
 export const CalculatorKeyboard = (props: Props) => {
     const numberFormatSettings = useAppSelector(selectNumberFormatSettings);
     const [theme] = useTheme();
+    const buttonGap = theme.spacing / 2;
 
     return (
-        <View style={[styles.mainLayout, { borderTopColor: theme.colors.outlineVariant, backgroundColor: theme.colors.elevation.level1 }]}>
-            <View style={styles.numberLayout}>
-                <View style={styles.numberRow}>
+        <View
+            style={[styles.mainLayout, {
+                borderTopColor: theme.colors.outlineVariant,
+                backgroundColor: theme.colors.elevation.level1,
+                borderTopLeftRadius: theme.roundness * 3,
+                borderTopRightRadius: theme.roundness * 3,
+                padding: theme.spacing,
+                gap: theme.spacing,
+            }]}
+        >
+            <View style={[styles.numberLayout, { gap: buttonGap }]}>
+                <View style={[styles.numberRow, { gap: buttonGap }]}>
                     <KeyboardButton
                         value='AC'
                         variant='action'
@@ -37,22 +47,22 @@ export const CalculatorKeyboard = (props: Props) => {
                         onPress={props.onBackPress}
                     />
                 </View>
-                <View style={styles.numberRow}>
+                <View style={[styles.numberRow, { gap: buttonGap }]}>
                     <KeyboardNumberButton number={7} onPress={props.onDigitPress} />
                     <KeyboardNumberButton number={8} onPress={props.onDigitPress} />
                     <KeyboardNumberButton number={9} onPress={props.onDigitPress} />
                 </View>
-                <View style={styles.numberRow}>
+                <View style={[styles.numberRow, { gap: buttonGap }]}>
                     <KeyboardNumberButton number={4} onPress={props.onDigitPress} />
                     <KeyboardNumberButton number={5} onPress={props.onDigitPress} />
                     <KeyboardNumberButton number={6} onPress={props.onDigitPress} />
                 </View>
-                <View style={styles.numberRow}>
+                <View style={[styles.numberRow, { gap: buttonGap }]}>
                     <KeyboardNumberButton number={3} onPress={props.onDigitPress} />
                     <KeyboardNumberButton number={2} onPress={props.onDigitPress} />
                     <KeyboardNumberButton number={1} onPress={props.onDigitPress} />
                 </View>
-                <View style={styles.numberRow}>
+                <View style={[styles.numberRow, { gap: buttonGap }]}>
                     <KeyboardButton
                         value='Cancel'
                         variant='action'
@@ -66,7 +76,7 @@ export const CalculatorKeyboard = (props: Props) => {
                     />
                 </View>
             </View>
-            <View style={styles.operatorLayout}>
+            <View style={[styles.operatorLayout, { gap: buttonGap }]}>
                 <KeyboardButton value='-' variant='action' onPress={props.onOperatorSubtractPress} />
                 <KeyboardButton value='+' variant='action' onPress={props.onOperatorAddPress} />
                 <KeyboardButton value='=' variant='action' onPress={props.onCalculatePress} />
@@ -79,16 +89,17 @@ export const CalculatorKeyboard = (props: Props) => {
 const styles = StyleSheet.create({
     mainLayout: {
         flexDirection: 'row',
-        justifyContent: 'space-evenly',
         borderTopWidth: 1,
         position: 'absolute',
         bottom: 0,
+        left: 0,
+        right: 0,
     },
     numberLayout: {
-        width: '82%',
+        flex: 5,
     },
     operatorLayout: {
-        width: '18%',
+        flex: 1,
     },
     numberRow: {
         flexDirection: 'row',

--- a/src/Screens/CalculatorScreen/CalculatorKeyboard.tsx
+++ b/src/Screens/CalculatorScreen/CalculatorKeyboard.tsx
@@ -4,6 +4,7 @@ import { KeyboardButton } from './KeyboardButton';
 import { KeyboardNumberButton } from './KeyboardNumberButton';
 import { useAppSelector } from '../../Hooks/useAppSelector';
 import { selectNumberFormatSettings } from '../../redux/features/displaySettings/displaySettingsSlice';
+import { useTheme } from '../../Hooks/useTheme';
 
 type Props = {
     onDigitPress: (digit: number) => void
@@ -19,9 +20,10 @@ type Props = {
 
 export const CalculatorKeyboard = (props: Props) => {
     const numberFormatSettings = useAppSelector(selectNumberFormatSettings);
+    const [theme] = useTheme();
 
     return (
-        <View style={styles.mainLayout}>
+        <View style={[styles.mainLayout, { borderTopColor: theme.colors.outlineVariant }]}>
             <View style={styles.numberLayout}>
                 <View style={styles.numberRow}>
                     <KeyboardButton
@@ -78,7 +80,6 @@ const styles = StyleSheet.create({
     mainLayout: {
         flexDirection: 'row',
         justifyContent: 'space-evenly',
-        borderTopColor: 'grey',
         borderTopWidth: 1,
         position: 'absolute',
         bottom: 0,

--- a/src/Screens/CalculatorScreen/CalculatorKeyboard.tsx
+++ b/src/Screens/CalculatorScreen/CalculatorKeyboard.tsx
@@ -77,7 +77,7 @@ export const CalculatorKeyboard = (props: Props) => {
                 </View>
             </View>
             <View style={[styles.operatorLayout, { gap: buttonGap }]}>
-                <KeyboardButton value='-' variant='action' onPress={props.onOperatorSubtractPress} />
+                <KeyboardButton value='−' variant='action' onPress={props.onOperatorSubtractPress} />
                 <KeyboardButton value='+' variant='action' onPress={props.onOperatorAddPress} />
                 <KeyboardButton value='=' variant='action' onPress={props.onCalculatePress} />
                 <KeyboardButton value='OK' variant='action' onPress={props.onConfirmPress} />

--- a/src/Screens/CalculatorScreen/CalculatorScreen.tsx
+++ b/src/Screens/CalculatorScreen/CalculatorScreen.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { StackParameterList } from '../../Navigation/ScreenParameters';
 import { CalculatorKeyboard } from './CalculatorKeyboard';
-import { View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 import { Calculation } from '../../Helper/Calculation';
 import { ScreenNames } from '../../Navigation/ScreenNames';
 import { useAppSelector } from '../../Hooks/useAppSelector';
@@ -89,6 +89,25 @@ export const CalculatorScreen = ({ route, navigation }: Props) => {
     );
 
     const [theme] = useTheme();
+
+    const resultText: string = useMemo(
+        () => {
+            const currentResult = new Calculation(currentCalculation, numberFormatSettings).getResult();
+            return convertNumberToText(currentResult);
+        },
+        [currentCalculation, numberFormatSettings, convertNumberToText],
+    );
+
+    const calculationScrollRef = useRef<ScrollView>(null);
+    const resultScrollRef = useRef<ScrollView>(null);
+
+    useEffect(() => {
+        calculationScrollRef.current?.scrollToEnd({ animated: false });
+    }, [currentCalculation]);
+
+    useEffect(() => {
+        resultScrollRef.current?.scrollToEnd({ animated: false });
+    }, [resultText]);
 
     const navigationBarAddition = useMemo(
         () => (
@@ -179,30 +198,33 @@ export const CalculatorScreen = ({ route, navigation }: Props) => {
         [navigation],
     );
 
-    const resultText: string = useMemo(
-        () => {
-            const currentResult = new Calculation(currentCalculation, numberFormatSettings).getResult();
-            return convertNumberToText(currentResult);
-        },
-        [currentCalculation, numberFormatSettings, convertNumberToText],
-    );
-
     return (
         <View style={{ flex: 1, padding: theme.spacing }}>
             <CardSurface elevation={1}>
                 <View style={{ padding: theme.spacing }}>
-                    <Text
-                        variant='displaySmall'
-                        style={{ textAlign: 'right' }}
+                    <ScrollView
+                        ref={calculationScrollRef}
+                        horizontal={true}
+                        showsHorizontalScrollIndicator={false}
+                        contentContainerStyle={{ flexGrow: 1, justifyContent: 'flex-end' }}
                     >
-                        {currentCalculation}
-                    </Text>
-                    <Text
-                        variant='headlineMedium'
-                        style={{ textAlign: 'right', color: theme.colors.onSurfaceVariant }}
+                        <Text variant='displaySmall'>
+                            {currentCalculation}
+                        </Text>
+                    </ScrollView>
+                    <ScrollView
+                        ref={resultScrollRef}
+                        horizontal={true}
+                        showsHorizontalScrollIndicator={false}
+                        contentContainerStyle={{ flexGrow: 1, justifyContent: 'flex-end' }}
                     >
-                        {`= ${resultText}`}
-                    </Text>
+                        <Text
+                            variant='headlineMedium'
+                            style={{ color: theme.colors.onSurfaceVariant }}
+                        >
+                            {`= ${resultText}`}
+                        </Text>
+                    </ScrollView>
                 </View>
             </CardSurface>
             <CalculatorKeyboard

--- a/src/Screens/CalculatorScreen/CalculatorScreen.tsx
+++ b/src/Screens/CalculatorScreen/CalculatorScreen.tsx
@@ -201,7 +201,7 @@ export const CalculatorScreen = ({ route, navigation }: Props) => {
                         variant='headlineMedium'
                         style={{ textAlign: 'right', color: theme.colors.onSurfaceVariant }}
                     >
-                        {resultText}
+                        {`= ${resultText}`}
                     </Text>
                 </View>
             </CardSurface>

--- a/src/Screens/CalculatorScreen/CalculatorScreen.tsx
+++ b/src/Screens/CalculatorScreen/CalculatorScreen.tsx
@@ -3,7 +3,7 @@ import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { StackParameterList } from '../../Navigation/ScreenParameters';
 import { CalculatorKeyboard } from './CalculatorKeyboard';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 import { Calculation } from '../../Helper/Calculation';
 import { ScreenNames } from '../../Navigation/ScreenNames';
 import { useAppSelector } from '../../Hooks/useAppSelector';
@@ -12,6 +12,7 @@ import { Appbar, Text } from 'react-native-paper';
 import { useAmountConversion } from '../../Hooks/useAmountConversion';
 import { useNavigationSettings } from '../../Hooks/useNavigationSettings';
 import { useTheme } from '../../Hooks/useTheme';
+import { CardSurface } from '../../Component/CardSurface';
 
 type ScreenName = 'Calculator';
 
@@ -187,15 +188,23 @@ export const CalculatorScreen = ({ route, navigation }: Props) => {
     );
 
     return (
-        <View style={styles.container}>
-            <View>
-                <Text style={[styles.text, styles.calculation]}>
-                    {currentCalculation}
-                </Text>
-                <Text style={[styles.text, styles.result]}>
-                    {resultText}
-                </Text>
-            </View>
+        <View style={{ flex: 1, padding: theme.spacing }}>
+            <CardSurface elevation={1}>
+                <View style={{ padding: theme.spacing }}>
+                    <Text
+                        variant='displaySmall'
+                        style={{ textAlign: 'right' }}
+                    >
+                        {currentCalculation}
+                    </Text>
+                    <Text
+                        variant='headlineMedium'
+                        style={{ textAlign: 'right', color: theme.colors.onSurfaceVariant }}
+                    >
+                        {resultText}
+                    </Text>
+                </View>
+            </CardSurface>
             <CalculatorKeyboard
                 onDigitPress={onDigitPress}
                 onDecimalSeparatorPress={onDecimalSeparatorPress}
@@ -210,23 +219,3 @@ export const CalculatorScreen = ({ route, navigation }: Props) => {
         </View>
     );
 };
-
-const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        justifyContent: 'space-between', // Ensures display is at top, keyboard at bottom
-    },
-    calculation: {
-        fontSize: 40,
-    },
-    result: {
-        fontSize: 30,
-    },
-    text: {
-        textAlign: 'right',
-        margin: 10,
-    },
-    historyButton: {
-        marginRight: 10,
-    },
-});

--- a/src/Screens/CalculatorScreen/CalculatorScreen.tsx
+++ b/src/Screens/CalculatorScreen/CalculatorScreen.tsx
@@ -36,7 +36,7 @@ export const CalculatorScreen = ({ route, navigation }: Props) => {
     const defaultCalculation: string = useMemo(
         () => {
             if (routePreviousCalculations.length === 0) {
-                return convertNumberToText(currentAmount);
+                return currentAmount === 0 ? '' : convertNumberToText(currentAmount);
             }
 
             const lastCalculation = routePreviousCalculations[routePreviousCalculations.length - 1];

--- a/src/Screens/CalculatorScreen/KeyboardButton.tsx
+++ b/src/Screens/CalculatorScreen/KeyboardButton.tsx
@@ -10,12 +10,12 @@ type Props = {
 
 export const KeyboardButton = ({ value, variant, onPress }: Props) => {
     const theme = useTheme();
-    const backgroundColor = variant === 'action' ? theme.colors.surfaceVariant : theme.colors.surface;
+    const backgroundColor = variant === 'action' ? theme.colors.secondaryContainer : theme.colors.elevation.level1;
 
     return (
         <Pressable
             style={({ pressed }) => [
-                { backgroundColor: pressed ? theme.colors.surfaceVariant : backgroundColor },
+                { backgroundColor: pressed ? theme.colors.primaryContainer : backgroundColor },
                 styles.pressable,
             ]}
             onPress={onPress}

--- a/src/Screens/CalculatorScreen/KeyboardButton.tsx
+++ b/src/Screens/CalculatorScreen/KeyboardButton.tsx
@@ -15,7 +15,10 @@ export const KeyboardButton = ({ value, variant, onPress }: Props) => {
     return (
         <Pressable
             style={({ pressed }) => [
-                { backgroundColor: pressed ? theme.colors.primaryContainer : backgroundColor },
+                {
+                    backgroundColor: pressed ? theme.colors.primaryContainer : backgroundColor,
+                    borderRadius: theme.roundness * 2,
+                },
                 styles.pressable,
             ]}
             onPress={onPress}


### PR DESCRIPTION
- Wrap the display area in a `CardSurface` and use MD3 `Text` variants (`displaySmall` for the expression, `headlineMedium` for the result)
- Prefix the result line with `=` to clearly distinguish it from the expression
- Replace line-breaking text with horizontal `ScrollView`s that auto-scroll to the newest input
- Open with an empty display when the current amount is zero instead of showing `0,00`
- Give the keyboard a teal background, rounded top corners, gaps between buttons, and rounded button corners to match the dark mode design
- Replace the hardcoded grey keyboard border with `theme.colors.outlineVariant`
- Replace the hyphen-minus `-` operator button with the proper Unicode minus sign `−` (U+2212)